### PR TITLE
fix crypto withdrawal response discrepancy with docs

### DIFF
--- a/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
+++ b/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
@@ -112,7 +112,8 @@ instance FromJSON CryptoWithdrawalResponse where
     <*> (read <$> o .: "amount")
     <*> o .: "currency"
     <*> ((read <$> o .: "fee") <|> (o .: "fee"))
-    <*> (read <$> o .: "subtotal")
+    <*> ((read <$> o .: "subtotal") <|> (o .: "subtotal"))
+    
 
 
 newtype WithdrawalFeeEstimateResponse = WithdrawalFeeEstimateResponse

--- a/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
+++ b/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
@@ -22,6 +22,7 @@ import           Data.UUID                          (UUID)
 
 import           CoinbasePro.Authenticated.Accounts (AccountId)
 import           CoinbasePro.Authenticated.Payment  (PaymentMethodId)
+import           Control.Applicative
 
 
 data WithdrawalDetails = WithdrawalDetails
@@ -110,7 +111,7 @@ instance FromJSON CryptoWithdrawalResponse where
     <$> o .: "id"
     <*> (read <$> o .: "amount")
     <*> o .: "currency"
-    <*> (read <$> o .: "fee")
+    <*> ((read <$> o .: "fee") <|> (o .: "fee"))
     <*> (read <$> o .: "subtotal")
 
 


### PR DESCRIPTION
Coinbase's docs show the withdrawal response as a string, but it's coming back as a number in the JSON, so have an alternative parser for now that allows for both.
