### PR TITLE
Viewing Transfer details

### DIFF
--- a/src/lib/CoinbasePro/Authenticated/Transfer.hs
+++ b/src/lib/CoinbasePro/Authenticated/Transfer.hs
@@ -5,6 +5,8 @@ module CoinbasePro.Authenticated.Transfer
     ( TransferType (..)
     , Transfer (..)
     , TransferDetails (..)
+    , WithdrawalTransfer (..)
+    , DepositTransfer (..)
     ) where
 
 import           Data.Aeson                           (FromJSON (..), ToJSON,

--- a/src/lib/CoinbasePro/Authenticated/Transfer.hs
+++ b/src/lib/CoinbasePro/Authenticated/Transfer.hs
@@ -4,6 +4,7 @@
 module CoinbasePro.Authenticated.Transfer
     ( TransferType (..)
     , Transfer (..)
+    , TransferDetails (..)
     ) where
 
 import           Data.Aeson                           (FromJSON (..), ToJSON,

--- a/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
+++ b/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
@@ -23,6 +23,7 @@ import           Data.UUID                          (UUID)
 import           CoinbasePro.Authenticated.Accounts (AccountId)
 import           CoinbasePro.Authenticated.Payment  (PaymentMethodId)
 import           Control.Applicative
+import Text.Read (readMaybe)
 
 
 data WithdrawalDetails = WithdrawalDetails
@@ -47,8 +48,8 @@ instance FromJSON WithdrawalDetails where
     <*> o .:? "coinbase_withdrawal_id"
     <*> o .:? "coinbase_transaction_id"
     <*> o .: "coinbase_payment_method_id"
-    <*> (maybe Nothing read <$> o .:? "fee")
-    <*> (maybe Nothing read <$> o .:? "subtotal")
+    <*> (maybe Nothing readMaybe <$> o .:? "fee")
+    <*> (maybe Nothing readMaybe <$> o .:? "subtotal")
 
 
 data WithdrawalRequest = WithdrawalRequest


### PR DESCRIPTION
If read is used instead of readMaybe, it crashes at runtime.

Also export more data constructors so the details can be viewed individually.